### PR TITLE
Add support for Enchantment Descriptions.

### DIFF
--- a/common/src/main/resources/assets/aileron/lang/en_us.json
+++ b/common/src/main/resources/assets/aileron/lang/en_us.json
@@ -1,6 +1,8 @@
 {
   "enchantment.aileron.smokestack": "Smokestack",
+  "enchantment.aileron.smokestack.desc": "Allows elytra boosts from campfires to be stored for later use.",
   "enchantment.aileron.cloudskipper": "Cloudskipper",
+  "enchantment.aileron.cloudskipper.desc": "Reduces horizontal elytra drag while above the cloud layer.",
   "aileron.midnightconfig.title": "Aileron Config",
   "aileron.midnightconfig.cameraSettings": "Camera Settings",
   "aileron.midnightconfig.doCameraRoll": "Tilt Camera on Turns",


### PR DESCRIPTION
This PR adds a language key to support mods like [Enchantment Descriptions](https://www.curseforge.com/minecraft/mc-mods/enchantment-descriptions) that show players descriptions of enchantments in-game. 